### PR TITLE
feat: make certificate durations configurable via environment variables

### DIFF
--- a/pkg/hostedcontrolplane/controller.go
+++ b/pkg/hostedcontrolplane/controller.go
@@ -83,7 +83,17 @@ func NewHostedControlPlaneReconciler(
 	recorder events.EventRecorder,
 	controllerNamespace string,
 	reconcileFilter string,
+	caCertificatesDuration time.Duration,
+	certificatesDuration time.Duration,
 ) HostedControlPlaneReconciler {
+	// Fallback to original defaults if the operator didn't override.
+	// Keeps backward compatibility for downstream callers (tests etc.).
+	if caCertificatesDuration <= 0 {
+		caCertificatesDuration = 2 * 24 * time.Hour
+	}
+	if certificatesDuration <= 0 {
+		certificatesDuration = 24 * time.Hour
+	}
 	return &hostedControlPlaneReconciler{
 		client:                         client,
 		managementClusterClient:        managementClusterClient,
@@ -98,8 +108,8 @@ func NewHostedControlPlaneReconciler(
 		controllerNamespace:            controllerNamespace,
 		controllerComponent:            "hosted-control-plane-controller",
 		reconcileFilter:                reconcileFilter,
-		caCertificatesDuration:         2 * 24 * time.Hour,
-		certificatesDuration:           24 * time.Hour,
+		caCertificatesDuration:         caCertificatesDuration,
+		certificatesDuration:           certificatesDuration,
 		apiServerComponentLabel:        "api-server",
 		apiServerServicePort:           int32(443),
 		etcdComponentLabel:             "etcd",

--- a/pkg/hostedcontrolplane/controller_test.go
+++ b/pkg/hostedcontrolplane/controller_test.go
@@ -74,6 +74,8 @@ func createTestReconcilerWithFilter(client client.Client, reconcileFilter string
 		&recorder.InfiniteDiscardingFakeRecorder{},
 		"test-namespace",
 		reconcileFilter,
+		0, // caCertificatesDuration: fallback to legacy default 48h
+		0, // certificatesDuration: fallback to legacy default 24h
 	)
 }
 

--- a/pkg/hostedcontrolplane/lifecycle_phases_test.go
+++ b/pkg/hostedcontrolplane/lifecycle_phases_test.go
@@ -268,6 +268,8 @@ func TestHostedControlPlane_FullLifecycle(t *testing.T) {
 		&recorder.InfiniteDiscardingFakeRecorder{},
 		"default",
 		"",
+		0, // caCertificatesDuration: fallback to legacy default 48h
+		0, // certificatesDuration: fallback to legacy default 24h
 	)
 
 	req := reconcile.Request{

--- a/pkg/operator/etc/config.go
+++ b/pkg/operator/etc/config.go
@@ -4,6 +4,7 @@ package etc
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	env "github.com/caarlos0/env/v6"
 )
@@ -28,6 +29,17 @@ type Config struct {
 	// ReconcileFilter, when non-empty, limits reconciliation to HostedControlPlanes whose name or
 	// owner Cluster name matches. Supports bare name or "namespace/name" format. Debugging aid only.
 	ReconcileFilter string `env:"HCP_RECONCILE_FILTER"`
+
+	// CACertificateDuration overrides the duration of CA certificates
+	// (cluster CA, etcd CA, front-proxy CA) created via cert-manager.
+	// Default 48h matches the original behavior. Industry-standard
+	// alternative: 87600h (10 years), matching kubeadm/RKE2/EKS defaults.
+	CACertificateDuration time.Duration `env:"CA_CERTIFICATE_DURATION" envDefault:"48h"`
+	// CertificateDuration overrides the duration of leaf certificates
+	// (apiserver, etcd peer/server, controller-manager kubeconfig, etc.).
+	// Default 24h matches the original behavior. Industry-standard
+	// alternative: 8760h (1 year), matching kubeadm/RKE2/EKS defaults.
+	CertificateDuration time.Duration `env:"CERTIFICATE_DURATION" envDefault:"24h"`
 }
 
 func GetOperatorConfig() (Config, error) {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -107,6 +107,8 @@ func Start(ctx context.Context, version string, operatorConfig etc.Config) (retE
 		operatorConfig.MaxConcurrentReconciles,
 		operatorConfig.ControllerNamespace,
 		operatorConfig.ReconcileFilter,
+		operatorConfig.CACertificateDuration,
+		operatorConfig.CertificateDuration,
 		tracerProvider, tracingWrapper,
 	); err != nil {
 		return err

--- a/pkg/reconcilers/certificates/reconciler.go
+++ b/pkg/reconcilers/certificates/reconciler.go
@@ -259,6 +259,16 @@ func (cr *certificateReconciler) createCertificateSpec(
 		usages = append(usages, certmanagerv1.UsageCertSign)
 	}
 
+	// Use renewBefore (absolute) instead of renewBeforePercentage to avoid
+	// a cert-manager webhook validation edge case observed with high
+	// durations: with `renewBeforePercentage: 50` and `duration: 87600h`
+	// (10y), the webhook rejected the patch with "renewBeforePercentage
+	// must result in a renewBefore greater than 5m0s" despite 50% of
+	// 87600h = 43800h being way more than 5m.
+	// `renewBefore = duration / 2` preserves the original 50% renew
+	// behavior in absolute terms, which the webhook validates correctly.
+	duration := slices.Ternary(isCA, cr.caCertificateDuration, cr.certificateDuration)
+	renewBefore := duration / 2
 	return certmanagerv1ac.CertificateSpec().
 		WithSecretName(secretName).
 		WithIssuerRef(certmanagermetav1ac.IssuerReference().
@@ -268,8 +278,8 @@ func (cr *certificateReconciler) createCertificateSpec(
 		WithUsages(usages...).
 		WithIsCA(isCA).
 		WithCommonName(commonName).
-		WithDuration(metav1.Duration{Duration: slices.Ternary(isCA, cr.caCertificateDuration, cr.certificateDuration)}).
-		WithRenewBeforePercentage(cr.certificateRenewBefore)
+		WithDuration(metav1.Duration{Duration: duration}).
+		WithRenewBefore(metav1.Duration{Duration: renewBefore})
 }
 
 func (cr *certificateReconciler) createCertificateSpecs(


### PR DESCRIPTION
## Summary

Allow operators to override the certificate durations (currently hardcoded to `24h` leaves / `48h` CAs in `pkg/hostedcontrolplane/controller.go`) via two new environment variables on the operator config :

- `CA_CERTIFICATE_DURATION` (default `48h` — unchanged)
- `CERTIFICATE_DURATION` (default `24h` — unchanged)

Zero breaking change at defaults. Operators wanting industry-standard durations (aligned with kubeadm / RKE2 / EKS / GKE) set them at deploy time :

```yaml
env:
  - name: CA_CERTIFICATE_DURATION
    value: "87600h"  # 10 years
  - name: CERTIFICATE_DURATION
    value: "8760h"   # 1 year
```

## Why

Issue #87 documents the production-breaking bug where leaf certs and CAs rotate at different cycles, eventually leaving leaf certs signed by a previous-generation CA. Any pod restart then loads the new CA but presents an old leaf cert → TLS chain break → `etcd` peer rejection, `kube-apiserver` unable to talk to `etcd`, etc.

The deeper rotation-handling fix proposed there is non-trivial. **This PR ships the simpler win** : let operators dial durations long enough that the rotation cascade happens once per ~6 months (leaves at 1y) and once per ~5 years (CAs at 10y) instead of daily. With industry-standard durations, the multi-cycle drift situation becomes vanishingly rare and planning maintenance around it is feasible.

Both fixes can coexist : this one ships today (zero-risk, defaults unchanged), the rotation-cascade fix lands when ready.

## Additional change : replace `renewBeforePercentage` with `renewBefore`

`WithRenewBeforePercentage(50)` replaced by `WithRenewBefore(duration/2)`. Same semantics (renew when half of lifetime has elapsed) but expressed as an absolute duration. Reason : when testing with long durations, the cert-manager webhook rejected the patch with :

```
spec.renewBeforePercentage: Invalid value: 50: certificate renewBeforePercentage must result in a renewBefore greater than 5m0s
```

50% of 87600h = 43800h is way more than 5m, so this looks like a numeric overflow or edge case in the cert-manager percentage→duration math. Using `renewBefore` as an absolute duration sidesteps the issue while preserving the original renew semantics.

If you'd rather keep `renewBeforePercentage` and ship only the env-var change, I can drop this hunk — just let me know.

## Changes

- `pkg/operator/etc/config.go` : 2 new env-tagged fields with original defaults
- `pkg/operator/operator.go` : wire env vars through `setupControllers` to the constructor
- `pkg/hostedcontrolplane/controller.go` : accept 2 new params with fallback to legacy defaults (caller backward-compat)
- `pkg/reconcilers/certificates/reconciler.go` : `WithRenewBefore(duration/2)` instead of `WithRenewBeforePercentage(50)`
- `pkg/hostedcontrolplane/controller_test.go` + `lifecycle_phases_test.go` : pass `0` for both durations in test helpers (falls back to legacy defaults, no test behavior change)

## Validation

Built and deployed on our production management cluster (CAPI / CAPMOX / Proxmox). 2 production HCP clusters previously stuck in TLS split-brain recovered cleanly. Certificate spec now stable :

- Leaves : `duration=8760h0m0s`, `renewBefore=4380h0m0s`
- CAs : `duration=87600h0m0s`, `renewBefore=43800h0m0s`
- `HostedControlPlane.status.APIServerAvailable=True`
- No controller errors in logs once cert-manager finished re-issuing

## Related

- Partial fix for #87 (durations-configurable subset only — the full rotation-cascade handling remains a separate concern)

Happy to iterate on naming, default values, or split this into smaller PRs if you'd prefer.