### PR TITLE
fix(node_rotation): add watch verb to machinedeployments/machinepools RBAC

### DIFF
--- a/pkg/reconcilers/node_rotation/reconciler.go
+++ b/pkg/reconcilers/node_rotation/reconciler.go
@@ -37,8 +37,8 @@ func NewNodeRotationReconciler(c client.Client, certManagerClient cmclient.Inter
 }
 
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get
-//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;patch;update
-//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools,verbs=get;list;patch;update
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch;patch;update
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools,verbs=get;list;watch;patch;update
 
 func (r *nodeRotationReconciler) ReconcileCARotation(
 	ctx context.Context,


### PR DESCRIPTION
The node rotation reconciler (added in #135) reads MachineDeployments/MachinePools through the controller-runtime cache, which needs both `list` and `watch`. The RBAC markers only grant `get;list;patch;update`, so the generated ClusterRole lacks `watch` and the informer fails:

```
machinedeployments.cluster.x-k8s.io is forbidden: User "system:serviceaccount:..." cannot watch resource "machinedeployments" ...
```

Result: the CA-rotation node rollout never reconciles. Adding `watch` to both markers fixes it. Observed on v1.7.0.