### PR TITLE
fix: correct renovate depName for konnectivity image

### DIFF
--- a/pkg/operator/util/images.go
+++ b/pkg/operator/util/images.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	maxKonnectivityMinor = 36 // renovate: datasource=docker depName=kas-network-proxy/konnectivity-server registryUrl=registry.k8s.io extractVersion=^v0\.(?<version>\d+)\.0$
+	maxKonnectivityMinor = 36 // renovate: datasource=docker depName=kas-network-proxy/proxy-server registryUrl=registry.k8s.io extractVersion=^v0\.(?<version>\d+)\.0$
 )
 
 func buildImageString(registry, repository, tag string) string {


### PR DESCRIPTION
## Summary
- The `// renovate:` custom-manager comment for `maxKonnectivityMinor` used `depName=kas-network-proxy/konnectivity-server`, which doesn't exist in `registry.k8s.io`. The actual images are `kas-network-proxy/proxy-agent` and `kas-network-proxy/proxy-server` (confirmed via the Artifact Registry API and matching code usage in `apiserverresources.go`/`konnectivity/reconciler.go`).
- Because the package didn't exist, Renovate silently found zero releases and never opened bump PRs for this constant.

## Test plan
- [x] `go-task lint` / pre-commit hook (tests + lint) passed locally
- [ ] Confirm Renovate picks up the dependency on next run (dependency dashboard / new PR against `maxKonnectivityMinor`)