### PR TITLE
refactor: share CA definitions between cert and bundle reconciliation

### DIFF
--- a/pkg/hostedcontrolplane/lifecycle_phases_test.go
+++ b/pkg/hostedcontrolplane/lifecycle_phases_test.go
@@ -337,7 +337,7 @@ func TestHostedControlPlane_FullLifecycle(t *testing.T) {
 				false: {
 					NewConditionVerification(
 						v1alpha1.CACertificatesReadyCondition,
-						Equal("KubernetesCaCertificateNotReady"),
+						ContainSubstring("KubernetesCaCertificateNotReady"),
 					),
 				},
 			},
@@ -348,7 +348,7 @@ func TestHostedControlPlane_FullLifecycle(t *testing.T) {
 				false: {
 					NewConditionVerification(
 						v1alpha1.CACertificatesReadyCondition,
-						Not(Equal("KubernetesCaCertificateNotReady")),
+						Not(ContainSubstring("KubernetesCaCertificateNotReady")),
 					),
 				},
 			},
@@ -359,7 +359,7 @@ func TestHostedControlPlane_FullLifecycle(t *testing.T) {
 				false: {
 					NewConditionVerification(
 						v1alpha1.CACertificatesReadyCondition,
-						Equal("KubernetesCaIssuerNotReady"),
+						ContainSubstring("KubernetesCaIssuerNotReady"),
 					),
 				},
 			},
@@ -368,7 +368,7 @@ func TestHostedControlPlane_FullLifecycle(t *testing.T) {
 				false: {
 					NewConditionVerification(
 						v1alpha1.CACertificatesReadyCondition,
-						Not(Equal("KubernetesCaIssuerNotReady")),
+						Not(ContainSubstring("KubernetesCaIssuerNotReady")),
 					),
 				},
 			},

--- a/pkg/reconcilers/certificates/reconciler.go
+++ b/pkg/reconcilers/certificates/reconciler.go
@@ -91,6 +91,54 @@ type certificateSpec struct {
 	customLabels map[string]string
 }
 
+// caDefinition is the single source of truth for a control plane CA: its certificate/secret/bundle
+// naming, the issuer it produces, and the (already-existing) issuer it's signed by. ReconcileCACertificates
+// and ReconcileCABundles both iterate this same list so a newly added CA can't be forgotten in one of
+// them.
+type caDefinition struct {
+	kind             string
+	commonName       string
+	certificateName  func(cluster *capiv2.Cluster) string
+	secretName       func(cluster *capiv2.Cluster) string
+	bundleSecretName func(cluster *capiv2.Cluster) string
+	issuerName       func(cluster *capiv2.Cluster) string
+	parentIssuerName func(cluster *capiv2.Cluster) string
+	duration         func(cr *certificateReconciler) time.Duration
+}
+
+var caDefinitions = []caDefinition{
+	{
+		kind:             "kubernetes CA",
+		commonName:       "kubernetes",
+		certificateName:  names.GetCACertificateName,
+		secretName:       names.GetCASecretName,
+		bundleSecretName: names.GetCABundleSecretName,
+		issuerName:       names.GetCAIssuerName,
+		parentIssuerName: names.GetRootIssuerName,
+		duration:         func(cr *certificateReconciler) time.Duration { return cr.rootCACertificateDuration },
+	},
+	{
+		kind:             "etcd CA",
+		commonName:       "etcd-ca",
+		certificateName:  names.GetEtcdCAName,
+		secretName:       names.GetEtcdCASecretName,
+		bundleSecretName: names.GetEtcdCABundleSecretName,
+		issuerName:       names.GetEtcdCAName,
+		parentIssuerName: names.GetCAIssuerName,
+		duration:         func(cr *certificateReconciler) time.Duration { return cr.caCertificateDuration },
+	},
+	{
+		kind:             "front-proxy CA",
+		commonName:       "front-proxy-ca",
+		certificateName:  names.GetFrontProxyCAName,
+		secretName:       names.GetFrontProxyCASecretName,
+		bundleSecretName: names.GetFrontProxyCABundleSecretName,
+		issuerName:       names.GetFrontProxyCAName,
+		parentIssuerName: names.GetCAIssuerName,
+		duration:         func(cr *certificateReconciler) time.Duration { return cr.caCertificateDuration },
+	},
+}
+
 //+kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=create;update;patch
 
 func (cr *certificateReconciler) ReconcileCACertificates(
@@ -101,29 +149,8 @@ func (cr *certificateReconciler) ReconcileCACertificates(
 	return tracing.WithSpan(ctx, cr.tracer, "ReconcileCACertificates",
 		func(ctx context.Context, span trace.Span) (string, error) {
 			issuerClient := cr.certManagerClient.CertmanagerV1().Issuers(hostedControlPlane.Namespace)
-			createCertificateSpec := func(
-				issuer *certmanagerv1.Issuer,
-				name string,
-				commonName string,
-				secretName string,
-				duration time.Duration,
-			) certificateSpec {
-				return certificateSpec{
-					kind: name,
-					spec: cr.createCertificateSpec(issuer.Name, commonName, secretName, true).
-						WithDuration(metav1.Duration{Duration: duration}),
-					customLabels: map[string]string{
-						names.CertificateKindLabel: string(names.CACertificateKind),
-					},
-				}
-			}
 
-			rootIssuerAC := cr.createIssuer(
-				hostedControlPlane,
-				cluster,
-				names.GetRootIssuerName(cluster),
-				"",
-			)
+			rootIssuerAC := cr.createIssuer(hostedControlPlane, cluster, names.GetRootIssuerName(cluster), "")
 
 			rootIssuer, err := issuerClient.Apply(ctx, rootIssuerAC, operatorutil.ApplyOptions)
 			if err != nil {
@@ -133,103 +160,62 @@ func (cr *certificateReconciler) ReconcileCACertificates(
 				return "root issuer not ready", nil
 			}
 
-			kubernetesCACertificate, ready, err := cr.reconcileCertificate(ctx, hostedControlPlane, cluster,
-				names.GetCACertificateName(cluster),
-				createCertificateSpec(
-					rootIssuer,
-					names.GetCACertificateName(cluster),
-					"kubernetes",
-					names.GetCASecretName(cluster),
-					cr.rootCACertificateDuration,
-				),
-			)
-			if err != nil {
-				return "", fmt.Errorf("failed to reconcile CA certificate: %w", err)
-			}
-			if !ready {
-				return "kubernetes CA certificate not ready", nil
-			}
-
-			kubernetesCAIssuerAC := cr.createIssuer(
-				hostedControlPlane,
-				cluster,
-				names.GetCAIssuerName(cluster),
-				kubernetesCACertificate.Spec.SecretName,
-			)
-
-			kubernetesCAIssuer, err := issuerClient.Apply(ctx, kubernetesCAIssuerAC, operatorutil.ApplyOptions)
-			if err != nil {
-				return "", fmt.Errorf("failed to patch CA issuer: %w", err)
-			}
-			if !cr.isIssuerReady(kubernetesCAIssuer) {
-				return "kubernetes CA issuer not ready", nil
-			}
-
 			var notReadyReasons []string
-
-			frontProxyCACertificate, ready, err := cr.reconcileCertificate(ctx, hostedControlPlane, cluster,
-				names.GetFrontProxyCAName(cluster),
-				createCertificateSpec(
-					kubernetesCAIssuer,
-					names.GetFrontProxyCAName(cluster),
-					"front-proxy-ca",
-					names.GetFrontProxyCASecretName(cluster),
-					cr.caCertificateDuration,
-				),
-			)
-			if err != nil {
-				return "", fmt.Errorf("failed to reconcile front-proxy CA certificate: %w", err)
-			}
-			if !ready {
-				notReadyReasons = append(notReadyReasons, "front-proxy CA certificate not ready")
-			} else {
-				frontProxyCAIssuerAC := cr.createIssuer(
-					hostedControlPlane,
-					cluster,
-					names.GetFrontProxyCAName(cluster),
-					frontProxyCACertificate.Spec.SecretName,
-				)
-
-				if frontProxyCAIssuer, err := issuerClient.Apply(ctx, frontProxyCAIssuerAC, operatorutil.ApplyOptions); err != nil {
-					return "", fmt.Errorf("failed to patch front-proxy CA issuer: %w", err)
-				} else if !cr.isIssuerReady(frontProxyCAIssuer) {
-					notReadyReasons = append(notReadyReasons, "front-proxy CA issuer not ready")
+			for _, def := range caDefinitions {
+				notReady, err := cr.reconcileCA(ctx, hostedControlPlane, cluster, def)
+				if err != nil {
+					return "", err
 				}
-			}
-
-			etcdCACertificate, ready, err := cr.reconcileCertificate(ctx, hostedControlPlane, cluster,
-				names.GetEtcdCAName(cluster),
-				createCertificateSpec(
-					kubernetesCAIssuer,
-					names.GetEtcdCAName(cluster),
-					"etcd-ca",
-					names.GetEtcdCASecretName(cluster),
-					cr.caCertificateDuration,
-				),
-			)
-			if err != nil {
-				return "", fmt.Errorf("failed to reconcile etcd CA certificate: %w", err)
-			}
-			if !ready {
-				notReadyReasons = append(notReadyReasons, "etcd CA certificate not ready")
-			} else {
-				etcdCAIssuerAC := cr.createIssuer(
-					hostedControlPlane,
-					cluster,
-					names.GetEtcdCAName(cluster),
-					etcdCACertificate.Spec.SecretName,
-				)
-
-				if etcdCAIssuer, err := issuerClient.Apply(ctx, etcdCAIssuerAC, operatorutil.ApplyOptions); err != nil {
-					return "", fmt.Errorf("failed to patch etcd CA issuer: %w", err)
-				} else if !cr.isIssuerReady(etcdCAIssuer) {
-					notReadyReasons = append(notReadyReasons, "etcd CA issuer not ready")
+				if notReady != "" {
+					notReadyReasons = append(notReadyReasons, notReady)
 				}
 			}
 
 			return strings.Join(notReadyReasons, ","), nil
 		},
 	)
+}
+
+// reconcileCA reconciles a CA certificate issued by def's parent issuer, then reconciles the issuer it
+// in turn produces so certificates one level below can be signed by it. The parent issuer doesn't need
+// to be ready yet: cert-manager leaves the certificate Pending until it is, which reconcileCertificate
+// reports as not-ready like any other certificate.
+func (cr *certificateReconciler) reconcileCA(
+	ctx context.Context,
+	hostedControlPlane *v1alpha1.HostedControlPlane,
+	cluster *capiv2.Cluster,
+	def caDefinition,
+) (string, error) {
+	certificate, ready, err := cr.reconcileCertificate(ctx, hostedControlPlane, cluster,
+		def.certificateName(cluster),
+		certificateSpec{
+			kind: def.kind,
+			spec: cr.createCertificateSpec(def.parentIssuerName(cluster), def.commonName, def.secretName(cluster), true).
+				WithDuration(metav1.Duration{Duration: def.duration(cr)}),
+			customLabels: map[string]string{
+				names.CertificateKindLabel: string(names.CACertificateKind),
+			},
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to reconcile %s certificate: %w", def.kind, err)
+	}
+	if !ready {
+		return fmt.Sprintf("%s certificate not ready", def.kind), nil
+	}
+
+	issuerAC := cr.createIssuer(hostedControlPlane, cluster, def.issuerName(cluster), certificate.Spec.SecretName)
+
+	issuer, err := cr.certManagerClient.CertmanagerV1().Issuers(hostedControlPlane.Namespace).
+		Apply(ctx, issuerAC, operatorutil.ApplyOptions)
+	if err != nil {
+		return "", fmt.Errorf("failed to patch %s issuer: %w", def.kind, err)
+	}
+	if !cr.isIssuerReady(issuer) {
+		return fmt.Sprintf("%s issuer not ready", def.kind), nil
+	}
+
+	return "", nil
 }
 
 func (cr *certificateReconciler) createIssuer(
@@ -476,28 +462,14 @@ func (cr *certificateReconciler) ReconcileCABundles(
 ) (string, error) {
 	return tracing.WithSpan(ctx, cr.tracer, "ReconcileCABundles",
 		func(ctx context.Context, _ trace.Span) (string, error) {
-			bundles := []struct {
-				kind             string
-				caSecretName     string
-				bundleSecretName string
-			}{
-				{"CA", names.GetCASecretName(cluster), names.GetCABundleSecretName(cluster)},
-				{"etcd CA", names.GetEtcdCASecretName(cluster), names.GetEtcdCABundleSecretName(cluster)},
-				{
-					"front-proxy CA",
-					names.GetFrontProxyCASecretName(cluster),
-					names.GetFrontProxyCABundleSecretName(cluster),
-				},
-			}
-
 			var notReadyReasons []string
-			for _, bundle := range bundles {
+			for _, def := range caDefinitions {
 				notReady, err := cr.reconcileCABundle(ctx, hostedControlPlane, cluster,
-					bundle.caSecretName,
-					bundle.bundleSecretName,
+					def.secretName(cluster),
+					def.bundleSecretName(cluster),
 				)
 				if err != nil {
-					return "", fmt.Errorf("failed to reconcile %s bundle: %w", bundle.kind, err)
+					return "", fmt.Errorf("failed to reconcile %s bundle: %w", def.kind, err)
 				}
 				if notReady != "" {
 					notReadyReasons = append(notReadyReasons, notReady)

--- a/pkg/reconcilers/certificates/reconciler_bundle_test.go
+++ b/pkg/reconcilers/certificates/reconciler_bundle_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/teutonet/cluster-api-provider-hosted-control-plane/api/v1alpha1"
-	"github.com/teutonet/cluster-api-provider-hosted-control-plane/pkg/operator/util/names"
 	. "github.com/teutonet/cluster-api-provider-hosted-control-plane/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,16 +39,18 @@ type caBundleFixture struct {
 	bundleSecretName string
 }
 
+// caBundleFixtures mirrors the production caDefinitions instead of hardcoding its own CA list, so it
+// can't drift from what ReconcileCABundles actually reconciles.
 func caBundleFixtures() []caBundleFixture {
-	return []caBundleFixture{
-		{"CA", names.GetCASecretName(bundleTestCluster), names.GetCABundleSecretName(bundleTestCluster)},
-		{"etcd CA", names.GetEtcdCASecretName(bundleTestCluster), names.GetEtcdCABundleSecretName(bundleTestCluster)},
-		{
-			"front-proxy CA",
-			names.GetFrontProxyCASecretName(bundleTestCluster),
-			names.GetFrontProxyCABundleSecretName(bundleTestCluster),
-		},
+	fixtures := make([]caBundleFixture, len(caDefinitions))
+	for i, def := range caDefinitions {
+		fixtures[i] = caBundleFixture{
+			def.kind,
+			def.secretName(bundleTestCluster),
+			def.bundleSecretName(bundleTestCluster),
+		}
 	}
+	return fixtures
 }
 
 func newBundleReconciler(kubeClient *fake.Clientset) *certificateReconciler {

--- a/pkg/reconcilers/certificates/reconciler_ca_certificates_test.go
+++ b/pkg/reconcilers/certificates/reconciler_ca_certificates_test.go
@@ -1,0 +1,128 @@
+package certificates
+
+import (
+	"testing"
+	"time"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmfake "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
+	. "github.com/onsi/gomega"
+	"github.com/teutonet/cluster-api-provider-hosted-control-plane/pkg/operator/util/names"
+	. "github.com/teutonet/cluster-api-provider-hosted-control-plane/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newCAReconciler(cmClient *cmfake.Clientset) *certificateReconciler {
+	return &certificateReconciler{
+		certManagerClient:         cmClient,
+		rootCACertificateDuration: time.Hour,
+		caCertificateDuration:     time.Hour,
+		tracer:                    "test",
+	}
+}
+
+func readyIssuer(name string) *certmanagerv1.Issuer {
+	return &certmanagerv1.Issuer{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: bundleTestHCP.Namespace},
+		Status: certmanagerv1.IssuerStatus{
+			Conditions: []certmanagerv1.IssuerCondition{
+				{Type: certmanagerv1.IssuerConditionReady, Status: certmanagermetav1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func readyCertificate(name string, secretName string) *certmanagerv1.Certificate {
+	return &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: bundleTestHCP.Namespace},
+		Spec:       certmanagerv1.CertificateSpec{SecretName: secretName},
+		Status: certmanagerv1.CertificateStatus{
+			Conditions: []certmanagerv1.CertificateCondition{
+				{Type: certmanagerv1.CertificateConditionReady, Status: certmanagermetav1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func TestReconcileCACertificates_AllReady(t *testing.T) {
+	g, ctx, _ := G(t)
+
+	rootIssuerName := names.GetRootIssuerName(bundleTestCluster)
+	kubeCAIssuerName := names.GetCAIssuerName(bundleTestCluster)
+	etcdCAName := names.GetEtcdCAName(bundleTestCluster)
+	frontProxyCAName := names.GetFrontProxyCAName(bundleTestCluster)
+
+	cmClient := cmfake.NewClientset(
+		readyIssuer(rootIssuerName),
+		readyCertificate(names.GetCACertificateName(bundleTestCluster), names.GetCASecretName(bundleTestCluster)),
+		readyIssuer(kubeCAIssuerName),
+		readyCertificate(etcdCAName, names.GetEtcdCASecretName(bundleTestCluster)),
+		readyIssuer(etcdCAName),
+		readyCertificate(frontProxyCAName, names.GetFrontProxyCASecretName(bundleTestCluster)),
+		readyIssuer(frontProxyCAName),
+	)
+	r := newCAReconciler(cmClient)
+
+	notReady, err := r.ReconcileCACertificates(ctx, bundleTestHCP, bundleTestCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(notReady).To(BeEmpty())
+
+	certificateClient := cmClient.CertmanagerV1().Certificates(bundleTestHCP.Namespace)
+	etcdCert, err := certificateClient.Get(ctx, etcdCAName, metav1.GetOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(etcdCert.Spec.IssuerRef.Name).To(Equal(kubeCAIssuerName))
+
+	frontProxyCert, err := certificateClient.Get(ctx, frontProxyCAName, metav1.GetOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(frontProxyCert.Spec.IssuerRef.Name).To(Equal(kubeCAIssuerName))
+}
+
+func TestReconcileCACertificates_RootIssuerNotReady(t *testing.T) {
+	g, ctx, _ := G(t)
+	r := newCAReconciler(cmfake.NewClientset())
+
+	notReady, err := r.ReconcileCACertificates(ctx, bundleTestHCP, bundleTestCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(notReady).To(Equal("root issuer not ready"))
+
+	certificates, err := r.certManagerClient.CertmanagerV1().Certificates(bundleTestHCP.Namespace).
+		List(ctx, metav1.ListOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(certificates.Items).To(BeEmpty())
+}
+
+func TestReconcileCACertificates_KubernetesCANotReady_AttemptsSiblingsAnyway(t *testing.T) {
+	g, ctx, _ := G(t)
+	rootIssuerName := names.GetRootIssuerName(bundleTestCluster)
+
+	cmClient := cmfake.NewClientset(readyIssuer(rootIssuerName))
+	r := newCAReconciler(cmClient)
+
+	notReady, err := r.ReconcileCACertificates(ctx, bundleTestHCP, bundleTestCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(notReady).To(Equal(
+		"kubernetes CA certificate not ready,etcd CA certificate not ready,front-proxy CA certificate not ready",
+	))
+}
+
+func TestReconcileCACertificates_IntermediateCertNotReady(t *testing.T) {
+	g, ctx, _ := G(t)
+
+	rootIssuerName := names.GetRootIssuerName(bundleTestCluster)
+	kubeCAIssuerName := names.GetCAIssuerName(bundleTestCluster)
+	frontProxyCAName := names.GetFrontProxyCAName(bundleTestCluster)
+
+	cmClient := cmfake.NewClientset(
+		readyIssuer(rootIssuerName),
+		readyCertificate(names.GetCACertificateName(bundleTestCluster), names.GetCASecretName(bundleTestCluster)),
+		readyIssuer(kubeCAIssuerName),
+		readyCertificate(frontProxyCAName, names.GetFrontProxyCASecretName(bundleTestCluster)),
+		readyIssuer(frontProxyCAName),
+	)
+	r := newCAReconciler(cmClient)
+
+	notReady, err := r.ReconcileCACertificates(ctx, bundleTestHCP, bundleTestCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(notReady).To(Equal("etcd CA certificate not ready"))
+}


### PR DESCRIPTION
## Summary
- `ReconcileCACertificates` and `ReconcileCABundles` each hardcoded their own list of the three control plane CAs (kubernetes, etcd, front-proxy); a newly added CA could easily be forgotten in one of them. Both now iterate a single `caDefinitions` list describing each CA's certificate/secret/bundle/issuer naming.
- `ReconcileCACertificates` no longer gates an intermediate CA on its parent issuer being ready before attempting it — cert-manager leaves the certificate `Pending` until the issuer is ready, which is reported as a not-ready reason like any other certificate. This means `status.conditions` can briefly list more than one not-ready CA at once, but each still drops out individually once ready.

## Test plan
- [x] `go-task test path=pkg/reconcilers/certificates`
- [x] `go-task test path=pkg/hostedcontrolplane` (full lifecycle integration test, updated for the new not-ready reason format)
- [x] `go-task lint`