### PR TITLE
fix: run go mod tidy after renovate updates go.mod

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
## Summary
- All 9 open renovate PRs currently fail CI's `check-diff` task: renovate bumps go.mod but leaves stale go.sum hash entries for the replaced version, and `check-diff` runs a real `go mod tidy` + diffs, catching the mismatch.
- Adds `postUpdateOptions: ["gomodTidy"]` so renovate tidies go.sum itself before opening PRs.

## Test plan
- [ ] Verify next renovate PR passes `check-diff` in CI