### PR TITLE
chore: let renovate track go tool versions in taskfile.yaml

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,17 @@
       "matchStrings": [
         "\"?(?<currentValue>[^\\s\"]+)\"?\\s*//\\s*renovate:\\s*datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( registryUrl=(?<registryUrl>\\S+))?( extractVersion=(?<extractVersion>\\S+))?( versioning=(?<versioning>\\S+))?"
       ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^taskfile\\.yaml$/"
+      ],
+      "matchStrings": [
+        "(?<depName>[\\w-]+):\\s+url: (?<packageName>\\S+?)(?:/cmd/[\\w-]+)?\\s+version: (?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "go",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a `regex` customManager to `.github/renovate.json` that tracks the `go run <module>@<version>` tool pins under `taskfile.yaml`'s `vars.tools.map` (controller-gen, conversion-gen, golangci-lint, gofumpt, golines, kustomize, grype, yq).
- One generic regex captures `depName`/`packageName`/`currentValue` per entry, stripping an optional trailing `/cmd/<bin>` from the URL so the `go` datasource resolves the correct module root (e.g. `sigs.k8s.io/controller-tools/cmd/controller-gen` → `sigs.k8s.io/controller-tools`) instead of needing one manager per tool.

## Test plan
- [x] `renovate-config-validator .github/renovate.json` passes
- [x] Verified the regex extracts correct depName/packageName/currentValue for all 8 tools against the current `taskfile.yaml`
- [x] Spot-checked `sigs.k8s.io/kustomize/kustomize/v5` and `github.com/golangci/golangci-lint/v2` against proxy.golang.org to confirm they resolve as real modules with matching version tags