### PR TITLE
chore: enable auto-merge for renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,8 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
+  "automerge": true,
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
## Summary
- Enable `automerge` + `platformAutomerge` in `.github/renovate.json`, matching the convention used in teutonet/teutonet-helm-charts.

## Test plan
- [x] `go-task lint` passes