### PR TITLE
chore: add renovate groups for aws and otel

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,24 @@
         "k8s.io/**"
       ],
       "groupName": "k8s.io Kubernetes modules"
+    },
+    {
+      "matchDatasources": [
+        "go"
+      ],
+      "matchPackageNames": [
+        "github.com/aws/**"
+      ],
+      "groupName": "AWS modules"
+    },
+    {
+      "matchDatasources": [
+        "go"
+      ],
+      "matchPackageNames": [
+        "go.opentelemetry.io/**"
+      ],
+      "groupName": "OpenTelemetry modules"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Group all go.mod updates under github.com/aws/** and go.opentelemetry.io/** into single PRs each, matching the existing k8s.io group.