### PR TITLE
feat: track coredns and nginx image versions via renovate

### DIFF
--- a/pkg/operator/util/images.go
+++ b/pkg/operator/util/images.go
@@ -8,7 +8,9 @@ import (
 )
 
 const (
-	maxKonnectivityMinor = 36 // renovate: datasource=docker depName=kas-network-proxy/proxy-server registryUrl=registry.k8s.io extractVersion=^v0\.(?<version>\d+)\.0$
+	maxKonnectivityMinor = 36        // renovate: datasource=docker depName=kas-network-proxy/proxy-server registryUrl=registry.k8s.io extractVersion=^v0\.(?<version>\d+)\.0$
+	coreDNSTag           = "v1.12.0" // renovate: datasource=docker depName=coredns/coredns registryUrl=registry.k8s.io extractVersion=^(?<version>v\d+\.\d+\.\d+)$
+	nginxTag             = "1.29.1"  // renovate: datasource=docker depName=nginx registryUrl=docker.io extractVersion=^(?<version>\d+\.\d+\.\d+)$
 )
 
 func buildImageString(registry, repository, tag string) string {
@@ -52,9 +54,9 @@ func ResolveKubeProxyImage(imageSpec *v1alpha1.ImageSpec, version string) string
 }
 
 func ResolveCoreDNSImage(imageSpec *v1alpha1.ImageSpec) string {
-	return resolveImageFromSpec(imageSpec, "registry.k8s.io", "coredns/coredns", "v1.12.0")
+	return resolveImageFromSpec(imageSpec, "registry.k8s.io", "coredns/coredns", coreDNSTag)
 }
 
 func ResolveNginxImage(imageSpec *v1alpha1.ImageSpec) string {
-	return resolveImageFromSpec(imageSpec, "docker.io", "nginx", "1.29.1")
+	return resolveImageFromSpec(imageSpec, "docker.io", "nginx", nginxTag)
 }

--- a/pkg/reconcilers/etcd_cluster/volume_stats/volume_stats.go
+++ b/pkg/reconcilers/etcd_cluster/volume_stats/volume_stats.go
@@ -137,7 +137,6 @@ func (p *kubeletEtcdVolumeStatsProvider) extractPodVolumeUsage(
 			if !isEtcdDataVolume(volStats) || volStats.UsedBytes == nil {
 				continue
 			}
-			//nolint:gosec // capped at MaxInt64
 			return int64(min(*volStats.UsedBytes, uint64(math.MaxInt64)))
 		}
 	}

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -26,7 +26,7 @@ vars:
         version: 0.36.3
       golangci-lint:
         url: github.com/golangci/golangci-lint/v2/cmd/golangci-lint
-        version: 2.12.2
+        version: 2.13.2
       gofumpt:
         url: mvdan.cc/gofumpt
         version: 0.11.0


### PR DESCRIPTION
Adds the same const + renovate annotation pattern used for maxKonnectivityMinor to the coredns and nginx image versions, so Renovate tracks and bumps them.

Also bumps golangci-lint to 2.13.2 (v2.12.2 panics on newer Go toolchains) and drops a //nolint:gosec directive that the newer version no longer needs.