### PR TITLE
chore: group sigs.k8s.io/controller-runtime with k8s.io renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,8 @@
         "go"
       ],
       "matchPackageNames": [
-        "k8s.io/**"
+        "k8s.io/**",
+        "sigs.k8s.io/controller-runtime"
       ],
       "groupName": "k8s.io Kubernetes modules"
     },

--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297 // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -367,8 +367,8 @@ go4.org v0.0.0-20260112195520-a5071408f32f h1:ziUVAjmTPwQMBmYR1tbdRFJPtTcQUI12fH
 go4.org v0.0.0-20260112195520-a5071408f32f/go.mod h1:ZRJnO5ZI4zAwMFp+dS1+V6J6MSyAowhRqAE+DPa1Xp0=
 go4.org/netipx v0.0.0-20231129151722-fdeea329fbba h1:0b9z3AuHCjxk0x/opv64kcgZLBseWJUpBw5I82+2U4M=
 go4.org/netipx v0.0.0-20231129151722-fdeea329fbba/go.mod h1:PLyyIXexvUFg3Owu6p/WfdlivPbZJsZdgWZlrGope/Y=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297 h1:YXnL44eJ77R+ji4/ooy8UsXIhz+lbi2Qgdlc8iRN0gY=
 golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297/go.mod h1:Mkmymgv+uMpSQ/XxJ/7GpdrdYoqm3u72jEbpCLiJmNk=
 golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=


### PR DESCRIPTION
## Summary
- `sigs.k8s.io/controller-runtime` minor versions are pinned to a specific `k8s.io/client-go` minor. #197 bumped controller-runtime alone (v0.24.1 → v0.25.0) without the rest of `k8s.io/*`, which broke the build (`k8s.io/kubernetes` v1.36.3 vs. `k8s.io/apiserver` v0.37.0 API skew). Adding it to the existing `k8s.io/**` renovate group prevents that from recurring.
- Also bumps `golang.org/x/crypto` to v0.56.0 to clear CVE-2026-56855/CVE-2026-78662, which the pre-commit vulnerability gate was flagging unrelated to this change.

## Test plan
- [x] `go-task test` / `go-task lint` / vulnerability scan all pass via the pre-commit hook